### PR TITLE
Electron Error Fix

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -17,16 +17,19 @@ module.exports = {
 		},
 	],
 	plugins: [
-		['@electron-forge/plugin-webpack', {
+	{
+		name: '@electron-forge/plugin-webpack', 
+		config: {
 			mainConfig: './webpack.main.config.js',
 			renderer: {
 				config: './webpack.renderer.config.js',
 				entryPoints: [{
 					html: './src/index.html',
 					js: './src/renderer/app.js',
-					name: 'main',
-				}],
-			},
-		}],
-	],
+					name: 'main'
+				}]
+			}
+		}
+	}
+	]
 }


### PR DESCRIPTION
this edits, fixes electron error about `Expected plugin to either be a plugin instance or a { name, config } object but found `
```
F:\drweiss-hud>yarn start
yarn run v1.22.19
$ electron-forge start
✔ Checking your system
✔ Locating application
✖ Loading configuration
  › Expected plugin to either be a plugin instance or a { name, config } object but found @electron-forge/plugin-webp…
◼ Preparing native dependencies
◼ Running generateAssets hook

An unhandled rejection has occurred inside Forge:
Error: Expected plugin to either be a plugin instance or a { name, config } object but found @electron-forge/plugin-webpack,[object Object]

Electron Forge was terminated. Location:
at F:\drweiss-hud\node_modules\@electron-forge\core\dist\util\plugin-interface.js:39:19
    at Array.map (<anonymous>)
    at new PluginInterface (F:\drweiss-hud\node_modules\@electron-forge\core\dist\util\plugin-interface.js:21:44)
    at Object._default [as default] (F:\drweiss-hud\node_modules\@electron-forge\core\dist\util\forge-config.js:157:43)
    at async Task.task (F:\drweiss-hud\node_modules\@electron-forge\core\dist\api\start.js:55:35)
    at async Task.run (F:\drweiss-hud\node_modules\listr2\dist\index.cjs:978:11)
    at async F:\drweiss-hud\node_modules\p-map\index.js:57:22
error Command failed with exit code 1.
```